### PR TITLE
Update to rustc 1.0.0-nightly (92ff8ea52 2015-01-27 23:08:13).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ doc
 bin
 target
 !.gitignore
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "signals"
 version = "0.1.0"
 authors = [ "mahkoh" ]
+license = "MIT"
 
-[[lib]]
+[lib]
 name = "signals"
+
+[[bin]]
+name = "test"
+path = "examples/test.rs"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,9 +1,8 @@
 extern crate signals;
-extern crate debug;
 
 fn main() {
     let sigs = signals::Signals::new().unwrap();
-    sigs.subscribe(signals::TermStop);
+    sigs.subscribe(signals::Signal::TermStop);
     for s in sigs.receiver().iter() {
         println!("{:?}", s);
     }


### PR DESCRIPTION
Deals with:
- Namespaced enums.
- Cargo changes (license, binary).
- Crate `debug` went away.
- Crate `libc` is unstable, added an allow.
- Name changes in `std::sync`.
- `box` becomes `Box::new`.
- `Iterator` has associated type rather than template parameter. 
